### PR TITLE
Use the real Knative Service URL instead of assuming example.com

### DIFF
--- a/info/lib/displayInfo.js
+++ b/info/lib/displayInfo.js
@@ -3,7 +3,7 @@
 const chalk = require('chalk')
 const { Context } = require('@serverless/core')
 const KnativeServing = require('@serverless/knative-serving')
-const { getNamespace, getFuncUrl } = require('../../shared/utils')
+const { getNamespace, getFuncName } = require('../../shared/utils')
 
 function displayInfo() {
   const { service } = this.serverless.service
@@ -14,13 +14,19 @@ function displayInfo() {
   const ctx = new Context()
   const serving = new KnativeServing(undefined, ctx)
 
-  return serving.info().then((res) => {
+  const inputs = {
+    namespace
+  }
+
+  return serving.info(inputs).then((res) => {
     let message = ''
 
     message += `${chalk.yellow.underline('Service Information')}\n`
     message += `${chalk.yellow('service:')} ${service}\n`
     message += `${chalk.yellow('namespace:')} ${namespace}\n`
-    message += `${chalk.yellow('ingress ip:')} ${res.istioIngressIp}\n`
+    if (res.istioIngressIp.length > 0) {
+      message += `${chalk.yellow('ingress ip:')} ${res.istioIngressIp}\n`
+    }
 
     message += '\n'
 
@@ -30,7 +36,7 @@ function displayInfo() {
     }
     functionNames.forEach((funcName) => {
       message += `${chalk.yellow(funcName)}:\n`
-      message += `  - ${chalk.yellow('url:')} ${getFuncUrl(service, funcName, stage)}\n`
+      message += `  - ${chalk.yellow('url:')} ${res.serviceUrls[getFuncName(service, funcName)]}\n`
       const events = this.serverless.service.getAllEventsInFunction(funcName)
       if (events.length) {
         events.forEach((event) => {


### PR DESCRIPTION
This plumbs through the Knative Service URLs returned from
https://github.com/serverless-components/knative-serving/pull/2 into
the CLI. This change depends on that
serverless-components/knative-serving one to get merged first and the
version bumped in package.json to provide the new Knative Service URLs.

This fixes #3.

It partially addresses #2 as well, but the actual function invocation
logic still tries the Istio IP if one is found. If not, it falls back
to directly using the Knative Service URL given.