### PR TITLE
Allow use of env variable for Kubernetes namespace

### DIFF
--- a/deploy/lib/ensureKnativeEvent.js
+++ b/deploy/lib/ensureKnativeEvent.js
@@ -13,7 +13,7 @@ function ensureKnativeEvent(funcName, eventName, config) {
   const eventing = new KnativeEventing(undefined, ctx)
 
   const sinkName = getFuncName(service, funcName)
-  const namespace = getNamespace(service, stage)
+  const namespace = getNamespace(this.serverless, stage)
   // TODO: this should be unique since we can have multiple such event definitions
   const name = getEventName(sinkName, eventName)
 

--- a/deploy/lib/ensureKnativeEvent.js
+++ b/deploy/lib/ensureKnativeEvent.js
@@ -13,7 +13,7 @@ function ensureKnativeEvent(funcName, eventName, config) {
   const eventing = new KnativeEventing(undefined, ctx)
 
   const sinkName = getFuncName(service, funcName)
-  const namespace = getNamespace(this.serverless, stage)
+  const namespace = getNamespace(this.serverless)
   // TODO: this should be unique since we can have multiple such event definitions
   const name = getEventName(sinkName, eventName)
 

--- a/deploy/lib/ensureKnativeService.js
+++ b/deploy/lib/ensureKnativeService.js
@@ -18,7 +18,7 @@ function ensureKnativeService(funcName) {
   const ctx = new Context()
   const serving = new KnativeServing(undefined, ctx)
 
-  const namespace = getNamespace(this.serverless, stage)
+  const namespace = getNamespace(this.serverless)
   const name = getFuncName(service, funcName)
 
   let registryAddress

--- a/deploy/lib/ensureKnativeService.js
+++ b/deploy/lib/ensureKnativeService.js
@@ -18,7 +18,7 @@ function ensureKnativeService(funcName) {
   const ctx = new Context()
   const serving = new KnativeServing(undefined, ctx)
 
-  const namespace = getNamespace(service, stage)
+  const namespace = getNamespace(this.serverless, stage)
   const name = getFuncName(service, funcName)
 
   let registryAddress

--- a/deploy/lib/ensureNamespace.js
+++ b/deploy/lib/ensureNamespace.js
@@ -11,7 +11,7 @@ function ensureNamespace() {
   const ctx = new Context()
   const namespace = new KubernetesNamespace(undefined, ctx)
 
-  const name = getNamespace(service, stage)
+  const name = getNamespace(this.serverless, stage)
 
   const inputs = {
     name,

--- a/deploy/lib/ensureNamespace.js
+++ b/deploy/lib/ensureNamespace.js
@@ -11,7 +11,7 @@ function ensureNamespace() {
   const ctx = new Context()
   const namespace = new KubernetesNamespace(undefined, ctx)
 
-  const name = getNamespace(this.serverless, stage)
+  const name = getNamespace(this.serverless)
 
   const inputs = {
     name,

--- a/info/lib/displayInfo.js
+++ b/info/lib/displayInfo.js
@@ -9,7 +9,7 @@ function displayInfo() {
   const { service } = this.serverless.service
   const stage = this.provider.getStage()
 
-  const namespace = getNamespace(service, stage)
+  const namespace = getNamespace(this.serverless, stage)
 
   const ctx = new Context()
   const serving = new KnativeServing(undefined, ctx)

--- a/info/lib/displayInfo.js
+++ b/info/lib/displayInfo.js
@@ -9,7 +9,7 @@ function displayInfo() {
   const { service } = this.serverless.service
   const stage = this.provider.getStage()
 
-  const namespace = getNamespace(this.serverless, stage)
+  const namespace = getNamespace(this.serverless)
 
   const ctx = new Context()
   const serving = new KnativeServing(undefined, ctx)

--- a/invoke/lib/invokeFunction.js
+++ b/invoke/lib/invokeFunction.js
@@ -10,7 +10,7 @@ function invokeFunction() {
   const { service } = this.serverless.service
   const stage = this.provider.getStage()
 
-  const namespace = getNamespace(service, stage)
+  const namespace = getNamespace(this.serverless, stage)
 
   const ctx = new Context()
   const serving = new KnativeServing(undefined, ctx)

--- a/invoke/lib/invokeFunction.js
+++ b/invoke/lib/invokeFunction.js
@@ -10,7 +10,7 @@ function invokeFunction() {
   const { service } = this.serverless.service
   const stage = this.provider.getStage()
 
-  const namespace = getNamespace(this.serverless, stage)
+  const namespace = getNamespace(this.serverless)
 
   const ctx = new Context()
   const serving = new KnativeServing(undefined, ctx)

--- a/remove/lib/removeNamespace.js
+++ b/remove/lib/removeNamespace.js
@@ -13,7 +13,7 @@ function removeNamespace() {
   const ctx = new Context()
   const namespace = new KubernetesNamespace(undefined, ctx)
 
-  const name = getNamespace(this.serverless, stage)
+  const name = getNamespace(this.serverless)
 
   const inputs = {
     name

--- a/remove/lib/removeNamespace.js
+++ b/remove/lib/removeNamespace.js
@@ -13,7 +13,7 @@ function removeNamespace() {
   const ctx = new Context()
   const namespace = new KubernetesNamespace(undefined, ctx)
 
-  const name = getNamespace(service, stage)
+  const name = getNamespace(this.serverless, stage)
 
   const inputs = {
     name

--- a/shared/utils.js
+++ b/shared/utils.js
@@ -3,9 +3,11 @@
 // TODO: make all of these functions configurable from the outside
 // the user should be able to manipulate those
 
-function getNamespace(service, stage) {
-  if(process.env.KUBE_NAMESPACE) {
-    return process.env.KUBE_NAMESPACE
+function getNamespace(serverless, stage) {
+  const { namespace } = serverless.service.provider.k8s
+  const { service } = serverless.service
+  if(namespace) {
+    return namespace
   }
   return `sls-${service}-${stage}`
 }
@@ -26,8 +28,9 @@ function getEventName(sinkName, eventName) {
   return `${sinkName}-${eventName}`.toLowerCase()
 }
 
-function getFuncUrl(service, funcName, stage) {
-  return `${getFuncName(service, funcName)}.${getNamespace(service, stage)}.example.com`
+function getFuncUrl(serverless, funcName, stage) {
+  const { service } = serverless.service
+  return `${getFuncName(service, funcName)}.${getNamespace(serverless, stage)}.example.com`
 }
 
 function isContainerImageUrl(str) {

--- a/shared/utils.js
+++ b/shared/utils.js
@@ -4,6 +4,9 @@
 // the user should be able to manipulate those
 
 function getNamespace(service, stage) {
+  if(process.env.KUBE_NAMESPACE) {
+    return process.env.KUBE_NAMESPACE
+  }
   return `sls-${service}-${stage}`
 }
 

--- a/shared/utils.js
+++ b/shared/utils.js
@@ -3,12 +3,13 @@
 // TODO: make all of these functions configurable from the outside
 // the user should be able to manipulate those
 
-function getNamespace(serverless, stage) {
-  const { namespace } = serverless.service.provider.k8s
-  const { service } = serverless.service
+function getNamespace(serverless) {
+  const namespace = serverless.service.provider.k8s?.namespace
   if(namespace) {
     return namespace
   }
+  const { service } = serverless.service
+  const stage = serverless.service.provider.stage
   return `sls-${service}-${stage}`
 }
 
@@ -28,9 +29,9 @@ function getEventName(sinkName, eventName) {
   return `${sinkName}-${eventName}`.toLowerCase()
 }
 
-function getFuncUrl(serverless, funcName, stage) {
+function getFuncUrl(serverless, funcName) {
   const { service } = serverless.service
-  return `${getFuncName(service, funcName)}.${getNamespace(serverless, stage)}.example.com`
+  return `${getFuncName(service, funcName)}.${getNamespace(serverless)}.example.com`
 }
 
 function isContainerImageUrl(str) {

--- a/shared/utils.js
+++ b/shared/utils.js
@@ -4,7 +4,8 @@
 // the user should be able to manipulate those
 
 function getNamespace(serverless) {
-  const namespace = serverless.service.provider.k8s?.namespace
+  const k8s = serverless.service.provider.k8s
+  const namespace = k8s && k8s.namespace
   if(namespace) {
     return namespace
   }


### PR DESCRIPTION
Currently, the Serverless Framework creates a specific Kubernetes namespace starting with `sls-` and that is a little limiting. 
This change would allow users to set the env var `KUBE_NAMESPACE` to overwrite the default and use the Kubernetes namespace they have already defined.